### PR TITLE
Fail for untitled buffers

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -3,6 +3,7 @@ from SublimeLinter.lint import NodeLinter
 
 class TSStandard(NodeLinter):
     name = 'ts-standard'
+    cmd = 'ts-standard --stdin --stdin-filename ${file}'
     regex = r'^.+:(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.+)'
     multiline = True
     defaults = {
@@ -10,17 +11,8 @@ class TSStandard(NodeLinter):
         'disable_if_not_dependency': False
     }
 
-    def cmd(self):
-        if self.context.get('file'):
-            return (
-                'ts-standard',
-                '--stdin',
-                '--stdin-filename',
-                '${file}'
-            )
-
-        self.notify_failure()
-        return (
-            'echo',
-            '<buffer>:1:1:The file must be saved before it can be linted by ts-standard'
-        )
+    def run(self, cmd, code):
+        if not self.context.get('file'):
+            self.notify_failure()
+            return '-:1:1:The file must be saved before it can be linted by ts-standard'
+        return super().run(cmd, code)


### PR DESCRIPTION
By implementing `run` we avoid running a subprocess to only return
a static string.  Since "echo" is a builtin on Windows this works across
the platforms as well.

Note that we also use "-" as the buffer name which is the canonical name
for "this buffer" or "stdin". SublimeLinter knows how to treat this
special name.